### PR TITLE
1.0.1: Fix coverlens.testRunner.customCommand being ignored (#4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Collect release metadata
         id: meta
         run: |
-          echo "version=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
+          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
           echo "run_url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
       - name: Check notification credentials
         id: secrets-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.0.1
+
+### Bug Fixes
+
+- **Fixed `coverlens.testRunner.customCommand` being ignored** ([#4](https://github.com/fogio-org/vscode-coverlens/issues/4)) — VSCode rejected the nested setting because `coverlens.testRunner` was declared as a string, causing a schema conflict. Renamed `coverlens.testRunner` to `coverlens.testRunner.mode` so both settings live under the same namespace.
+
+### Breaking Changes
+
+- `coverlens.testRunner` setting renamed to `coverlens.testRunner.mode` — update your `settings.json` if you set the runner explicitly.
+
 ## 1.0.0
 
 - Update extension logo

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Coverage from all packages is aggregated into one unified view. Configure manual
 | `coverlens.colors.uncovered` | — | Custom color for uncovered lines |
 | `coverlens.diffMode` | `false` | Show coverage only for changed lines |
 | `coverlens.diffBase` | `"HEAD"` | Git ref for diff mode comparison |
-| `coverlens.testRunner` | `"auto"` | Test runner: `auto`, `jest`, `vitest`, `pytest`, `go`, `cargo`, `dotnet`, `custom` |
+| `coverlens.testRunner.mode` | `"auto"` | Test runner: `auto`, `jest`, `vitest`, `pytest`, `go`, `cargo`, `dotnet`, `custom` |
 | `coverlens.testRunner.customCommand` | — | Custom shell command for test runner |
 | `coverlens.monorepo.enabled` | `true` | Auto-detect monorepo packages |
 | `coverlens.monorepo.packages` | `[]` | Manual package glob patterns |

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "coverlens",
   "displayName": "CoverLens",
   "description": "Three-state coverage lens with diff mode and monorepo support",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "fogio",
   "icon": "assets/icon.png",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
           "default": 80,
           "description": "Coverage % below which the file is marked yellow in the tree"
         },
-        "coverlens.testRunner": {
+        "coverlens.testRunner.mode": {
           "type": "string",
           "enum": [
             "auto",
@@ -229,7 +229,7 @@
         "coverlens.testRunner.customCommand": {
           "type": "string",
           "default": "",
-          "description": "Custom shell command to run tests with coverage (used when testRunner = 'custom')"
+          "description": "Custom shell command to run tests with coverage (used when testRunner.mode = 'custom')"
         },
         "coverlens.monorepo.enabled": {
           "type": "boolean",

--- a/src/runner/testRunner.ts
+++ b/src/runner/testRunner.ts
@@ -118,7 +118,7 @@ export class TestRunner {
 
   private resolveRunner(): { runnerKey: string; preset: RunnerPreset | null; customCmd: string } {
     const cfg = vscode.workspace.getConfiguration('coverlens');
-    let runnerKey = cfg.get<string>('testRunner', 'auto');
+    let runnerKey = cfg.get<string>('testRunner.mode', 'auto');
     const customCmd = cfg.get<string>('testRunner.customCommand', '');
 
     if (runnerKey === 'auto') {


### PR DESCRIPTION
### Bug Fixes

- **Fixed `coverlens.testRunner.customCommand` being ignored** ([#4](https://github.com/fogio-org/vscode-coverlens/issues/4)) — VSCode rejected the nested setting because `coverlens.testRunner` was declared as a string, causing a schema conflict. Renamed `coverlens.testRunner` to `coverlens.testRunner.mode` so both settings live under the same namespace.

### Breaking Changes

- `coverlens.testRunner` setting renamed to `coverlens.testRunner.mode` — update your `settings.json` if you set the runner explicitly.
