### PR TITLE
1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 1.0.2
+
+### Security
+
+- **Workspace Trust** — `coverlens.testRunner.customCommand` is no longer executed in untrusted workspaces. Opening a repository with a malicious `.vscode/settings.json` will not run arbitrary shell code anymore. Declared via the standard `capabilities.untrustedWorkspaces` manifest field.
+- **No more shell injection through scoped runs** — built-in presets (Jest/Vitest/pytest/Go) now spawn the runner with an argv array instead of formatting paths into a shell string. A directory whose name contains shell metacharacters can no longer cause command injection during `runOnSave: "package"`.
+
+### Bug Fixes
+
+- **Fixed `.sln` auto-detection never matching** — `detectRunner` was calling `fs.existsSync` with a literal `*.sln` glob. Replaced with a proper directory scan, so .NET projects without a `.csproj` next to the workspace root now resolve to the `dotnet` runner.
+- **`runOnSave` no longer triggers for unrelated files** — saves are now filtered by URI scheme (`file:` only), workspace membership and `coverlens.excludePatterns`. Saving a `README.md`, a file in `node_modules`, or a document in another workspace folder no longer kicks off a test run.
+- **Initial test run no longer swallows errors silently** — the fire-and-forget `runFullTests()` on activation now logs failures via the CoverLens output channel.
+
+### Improvements
+
+- **Async runner detection with per-workspace cache** — `detectRunner` switched from `fs.*Sync` to `fs.promises.*` and caches its result, removing a synchronous I/O burst from extension activation and from every test run.
+- **`enumDescriptions` for enum settings** — VSCode's settings UI now shows per-value documentation for `coverlens.testRunner.mode`, `coverlens.runOnSave`, `coverlens.onEdit` and `coverlens.decorationStyle`.
+- **`scope: "resource"` on runner settings** — `coverlens.testRunner.mode`, `coverlens.testRunner.customCommand` and `coverlens.runOnSave` can now be overridden per workspace folder, which matters in monorepos where different packages use different runners.
+- **Better test process supervision** — switched from `child_process.exec` to `child_process.spawn`, removing the 50 MB stdout buffer cap and streaming stderr into the log only on non-zero exits.
+
 ## 1.0.1
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "coverlens",
   "displayName": "CoverLens",
   "description": "Three-state coverage lens with diff mode and monorepo support",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "publisher": "fogio",
   "icon": "assets/icon.png",
   "engines": {
@@ -32,6 +32,12 @@
     "onStartupFinished"
   ],
   "main": "./dist/extension.js",
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": "limited",
+      "description": "Custom test commands (`coverlens.testRunner.customCommand`) are disabled in untrusted workspaces because they execute arbitrary shell code from workspace settings."
+    }
+  },
   "contributes": {
     "commands": [
       {
@@ -171,8 +177,12 @@
             "border",
             "highlight"
           ],
+          "enumDescriptions": [
+            "Vertical bar on the left edge of the line",
+            "Vertical bar plus a tinted background fill across the line"
+          ],
           "default": "border",
-          "description": "How to show coverage: 'border' = vertical bar on the left edge, 'highlight' = vertical bar + background fill"
+          "description": "How to render coverage on covered/partial/uncovered lines"
         },
         "coverlens.overviewRuler": {
           "type": "boolean",
@@ -182,14 +192,25 @@
         "coverlens.onEdit": {
           "type": "string",
           "enum": ["hide", "dim", "keep"],
+          "enumDescriptions": [
+            "Remove decorations once the file is dirty",
+            "Show decorations faded while the file is dirty",
+            "Leave decorations untouched while editing"
+          ],
           "default": "dim",
-          "description": "What to do with coverage when a file is edited: 'hide' = remove decorations, 'dim' = show faded, 'keep' = do nothing"
+          "description": "What to do with coverage decorations when a file is edited"
         },
         "coverlens.runOnSave": {
           "type": "string",
           "enum": ["off", "package", "all"],
+          "enumDescriptions": [
+            "Do not run tests on save",
+            "Run only the package/directory containing the saved file",
+            "Run the full test suite on every save"
+          ],
           "default": "package",
-          "description": "Auto-run tests on save: 'off' = disabled, 'package' = only affected package, 'all' = full test suite"
+          "scope": "resource",
+          "description": "Auto-run tests when a workspace file is saved (only triggers for files inside the workspace and outside excludePatterns)"
         },
         "coverlens.diffMode": {
           "type": "boolean",
@@ -223,13 +244,25 @@
             "dotnet",
             "custom"
           ],
+          "enumDescriptions": [
+            "Detect the runner from project files (go.mod, Cargo.toml, *.csproj/*.sln, pyproject.toml, vitest.config.*, jest.config.*, package.json)",
+            "Jest — `npx jest --coverage --coverageReporters=lcov`",
+            "Vitest — `npx vitest run --coverage --coverage.reporter=lcov`",
+            "pytest — `python -m pytest --cov=. --cov-report=lcov:lcov.info`",
+            "Go — `go test ./... -coverprofile=coverage.out`",
+            "Cargo (tarpaulin) — `cargo tarpaulin --out Lcov --output-dir .`",
+            ".NET (coverlet) — `dotnet test /p:CollectCoverage=true ...`",
+            "Run the shell command from `coverlens.testRunner.customCommand`"
+          ],
           "default": "auto",
+          "scope": "resource",
           "description": "Test runner for 'Run Tests with Coverage' command"
         },
         "coverlens.testRunner.customCommand": {
           "type": "string",
           "default": "",
-          "description": "Custom shell command to run tests with coverage (used when testRunner.mode = 'custom')"
+          "scope": "resource",
+          "markdownDescription": "Shell command to run tests when `#coverlens.testRunner.mode#` is `custom`. **Security:** this value is executed verbatim by your shell. Disabled in untrusted workspaces."
         },
         "coverlens.monorepo.enabled": {
           "type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { loadCoverage } from './coverage/loader';
 import { CoverageDecorator } from './decorations/decorator';
 import { CoverageTreeProvider } from './panel/coverageTree';
@@ -227,6 +228,8 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     vscode.workspace.onDidSaveTextDocument((doc) => {
       const mode = cfg().get<string>('runOnSave', 'package');
       if (mode === 'off' || mode === 'false' || !mode) return;
+      if (!shouldTriggerOnSave(doc, workspaceRoot, cfg().get<string[]>('excludePatterns', []))) return;
+
       const filePath = doc.uri.fsPath;
       if (runOnSaveTimeout) clearTimeout(runOnSaveTimeout);
       runOnSaveTimeout = setTimeout(async () => {
@@ -269,7 +272,7 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     await reload();
     // Then run full test suite if runOnSave is enabled
     if (cfg().get<string>('runOnSave', 'package') !== 'off') {
-      runFullTests(); // fire-and-forget — don't block activation
+      runFullTests().catch(err => log.error(`Initial test run failed: ${err}`));
     }
   }
 
@@ -277,3 +280,32 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
 }
 
 export function deactivate(): void {}
+
+/** Filter out saves that shouldn't trigger a test run (non-file URIs, files outside workspace, ignored paths). */
+function shouldTriggerOnSave(doc: vscode.TextDocument, workspaceRoot: string, excludePatterns: string[]): boolean {
+  if (doc.uri.scheme !== 'file') return false;
+
+  const filePath = doc.uri.fsPath;
+  const rel = path.relative(workspaceRoot, filePath);
+  if (!rel || rel.startsWith('..') || path.isAbsolute(rel)) return false;
+
+  const relPosix = rel.split(path.sep).join('/');
+  for (const pattern of excludePatterns) {
+    if (matchesGlob(relPosix, pattern)) return false;
+  }
+  return true;
+}
+
+function matchesGlob(relPath: string, glob: string): boolean {
+  let re = glob.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+  re = re.replace(/\*\*\//g, '(?:.*/)?');
+  re = re.replace(/\/\*\*/g, '(?:/.*)?');
+  re = re.replace(/\*\*/g, '.*');
+  re = re.replace(/\*/g, '[^/]*');
+  re = re.replace(/\?/g, '[^/]');
+  try {
+    return new RegExp(`^${re}$`).test(relPath);
+  } catch {
+    return false;
+  }
+}

--- a/src/runner/presets.ts
+++ b/src/runner/presets.ts
@@ -1,12 +1,17 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+export interface ScopedRun {
+  /** Argv (first element is the executable, rest are args). Pass with shell:true for cross-platform binary resolution. */
+  argv: string[];
+}
+
 export interface RunnerPreset {
   name: string;
-  /** Shell command that runs ALL tests and outputs a coverage file */
-  command: string;
-  /** Command template for running tests scoped to a specific directory/package */
-  scopedCommand?: (relativeDir: string) => string;
+  /** Argv for running ALL tests and outputting a coverage file */
+  argv: string[];
+  /** Builder for argv scoped to a specific directory (relative to workspace root) */
+  scoped?: (relativeDir: string) => ScopedRun;
   /** If scoped run writes to a separate file, specify it here for merging */
   scopedOutput?: string;
   /** Expected coverage output glob (relative to workspace root) */
@@ -16,82 +21,109 @@ export interface RunnerPreset {
 export const PRESETS: Record<string, RunnerPreset> = {
   jest: {
     name: 'Jest',
-    command: 'npx jest --coverage --coverageReporters=lcov',
-    scopedCommand: (dir) => `npx jest --coverage --coverageReporters=lcov --testPathPattern="${dir}"`,
+    argv: ['npx', 'jest', '--coverage', '--coverageReporters=lcov'],
+    scoped: (dir) => ({
+      argv: ['npx', 'jest', '--coverage', '--coverageReporters=lcov', `--testPathPattern=${dir}`]
+    }),
     outputGlob: 'coverage/lcov.info'
   },
   vitest: {
     name: 'Vitest',
-    command: 'npx vitest run --coverage --coverage.reporter=lcov',
-    scopedCommand: (dir) => `npx vitest run --coverage --coverage.reporter=lcov --dir "${dir}"`,
+    argv: ['npx', 'vitest', 'run', '--coverage', '--coverage.reporter=lcov'],
+    scoped: (dir) => ({
+      argv: ['npx', 'vitest', 'run', '--coverage', '--coverage.reporter=lcov', '--dir', dir]
+    }),
     outputGlob: 'coverage/lcov.info'
   },
   pytest: {
     name: 'pytest',
-    command: 'python -m pytest --cov=. --cov-report=lcov:lcov.info',
-    scopedCommand: (dir) => `python -m pytest "${dir}" --cov=. --cov-report=lcov:lcov.info`,
+    argv: ['python', '-m', 'pytest', '--cov=.', '--cov-report=lcov:lcov.info'],
+    scoped: (dir) => ({
+      argv: ['python', '-m', 'pytest', dir, '--cov=.', '--cov-report=lcov:lcov.info']
+    }),
     outputGlob: 'lcov.info'
   },
   go: {
     name: 'Go test',
-    command: 'go test ./... -coverprofile=coverage.out',
-    scopedCommand: (dir) => `go test ./${dir}/... -coverprofile=coverage.out.partial`,
+    argv: ['go', 'test', './...', '-coverprofile=coverage.out'],
+    scoped: (dir) => ({
+      argv: ['go', 'test', `./${dir.replace(/\\/g, '/')}/...`, '-coverprofile=coverage.out.partial']
+    }),
     scopedOutput: 'coverage.out.partial',
     outputGlob: 'coverage.out'
   },
   cargo: {
     name: 'Cargo (tarpaulin)',
-    command: 'cargo tarpaulin --out Lcov --output-dir .',
+    argv: ['cargo', 'tarpaulin', '--out', 'Lcov', '--output-dir', '.'],
     outputGlob: 'lcov.info'
   },
   dotnet: {
     name: '.NET (coverlet)',
-    command: 'dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./lcov.info',
+    argv: ['dotnet', 'test', '/p:CollectCoverage=true', '/p:CoverletOutputFormat=lcov', '/p:CoverletOutput=./lcov.info'],
     outputGlob: 'lcov.info'
   }
 };
 
-/** Auto-detect runner from files present in workspaceRoot */
-export function detectRunner(workspaceRoot: string): string {
+const detectCache = new Map<string, string>();
+
+async function exists(p: string): Promise<boolean> {
+  try { await fs.promises.access(p); return true; } catch { return false; }
+}
+
+async function hasFileWithExtension(dir: string, ext: string): Promise<boolean> {
+  try {
+    const entries = await fs.promises.readdir(dir);
+    return entries.some(f => f.endsWith(ext));
+  } catch {
+    return false;
+  }
+}
+
+/** Auto-detect runner from files present in workspaceRoot. Result is cached per workspace. */
+export async function detectRunner(workspaceRoot: string): Promise<string> {
+  const cached = detectCache.get(workspaceRoot);
+  if (cached) return cached;
+
+  const result = await detectRunnerImpl(workspaceRoot);
+  detectCache.set(workspaceRoot, result);
+  return result;
+}
+
+/** Clear cached detection (e.g. when workspace folders change). */
+export function clearDetectCache(): void {
+  detectCache.clear();
+}
+
+async function detectRunnerImpl(workspaceRoot: string): Promise<string> {
   const join = path.join;
 
-  if (fs.existsSync(join(workspaceRoot, 'go.mod'))) return 'go';
-  if (fs.existsSync(join(workspaceRoot, 'Cargo.toml'))) return 'cargo';
+  if (await exists(join(workspaceRoot, 'go.mod'))) return 'go';
+  if (await exists(join(workspaceRoot, 'Cargo.toml'))) return 'cargo';
 
-  // .NET: check for .csproj or .sln
-  if (fs.existsSync(join(workspaceRoot, '*.sln')) ||
-      hasFileWithExtension(workspaceRoot, '.csproj')) return 'dotnet';
+  if (await hasFileWithExtension(workspaceRoot, '.sln') ||
+      await hasFileWithExtension(workspaceRoot, '.csproj')) return 'dotnet';
 
-  if (fs.existsSync(join(workspaceRoot, 'pyproject.toml')) ||
-      fs.existsSync(join(workspaceRoot, 'setup.cfg')) ||
-      fs.existsSync(join(workspaceRoot, 'setup.py'))) return 'pytest';
+  if (await exists(join(workspaceRoot, 'pyproject.toml')) ||
+      await exists(join(workspaceRoot, 'setup.cfg')) ||
+      await exists(join(workspaceRoot, 'setup.py'))) return 'pytest';
 
-  if (fs.existsSync(join(workspaceRoot, 'vitest.config.ts')) ||
-      fs.existsSync(join(workspaceRoot, 'vitest.config.js')) ||
-      fs.existsSync(join(workspaceRoot, 'vitest.config.mjs'))) return 'vitest';
+  if (await exists(join(workspaceRoot, 'vitest.config.ts')) ||
+      await exists(join(workspaceRoot, 'vitest.config.js')) ||
+      await exists(join(workspaceRoot, 'vitest.config.mjs'))) return 'vitest';
 
-  if (fs.existsSync(join(workspaceRoot, 'jest.config.js')) ||
-      fs.existsSync(join(workspaceRoot, 'jest.config.ts')) ||
-      fs.existsSync(join(workspaceRoot, 'jest.config.mjs'))) return 'jest';
+  if (await exists(join(workspaceRoot, 'jest.config.js')) ||
+      await exists(join(workspaceRoot, 'jest.config.ts')) ||
+      await exists(join(workspaceRoot, 'jest.config.mjs'))) return 'jest';
 
-  // Check package.json for test scripts as last resort
-  if (fs.existsSync(join(workspaceRoot, 'package.json'))) {
+  if (await exists(join(workspaceRoot, 'package.json'))) {
     try {
-      const pkg = JSON.parse(fs.readFileSync(join(workspaceRoot, 'package.json'), 'utf8'));
+      const pkg = JSON.parse(await fs.promises.readFile(join(workspaceRoot, 'package.json'), 'utf8'));
       const testScript = pkg?.scripts?.test ?? '';
       if (testScript.includes('vitest')) return 'vitest';
       if (testScript.includes('jest')) return 'jest';
     } catch { /* ignore */ }
-    return 'jest'; // Node.js project, default to jest
+    return 'jest';
   }
 
   return 'jest';
-}
-
-function hasFileWithExtension(dir: string, ext: string): boolean {
-  try {
-    return fs.readdirSync(dir).some(f => f.endsWith(ext));
-  } catch {
-    return false;
-  }
 }

--- a/src/runner/testRunner.ts
+++ b/src/runner/testRunner.ts
@@ -5,11 +5,16 @@ import { PRESETS, RunnerPreset, detectRunner } from './presets';
 import { Logger } from '../util/logger';
 import { mergeGoCoverProfiles } from './mergeProfiles';
 
+interface ResolvedRunner {
+  runnerKey: string;
+  preset: RunnerPreset | null;
+  customCmd: string;
+}
+
 export class TestRunner {
   private activeProc: cp.ChildProcess | null = null;
   private _running = false;
 
-  /** Fires when running state changes (true = started, false = finished) */
   private readonly _onRunningChanged = new vscode.EventEmitter<boolean>();
   readonly onRunningChanged = this._onRunningChanged.event;
 
@@ -44,9 +49,14 @@ export class TestRunner {
   async run(): Promise<void> {
     this.setRunning(true);
     try {
-      const command = this.resolveCommand();
-      if (!command) return;
-      await this.execute(command);
+      const resolved = await this.resolveRunner();
+      if (resolved.runnerKey === 'custom' && resolved.customCmd) {
+        if (!this.assertTrustedForCustomCommand()) return;
+        await this.execShell(resolved.customCmd);
+        return;
+      }
+      if (!resolved.preset) return;
+      await this.execArgv(resolved.preset.argv);
     } finally {
       this.setRunning(false);
     }
@@ -56,38 +66,35 @@ export class TestRunner {
   async runScoped(filePath: string): Promise<void> {
     this.setRunning(true);
     try {
-      const { runnerKey, preset, customCmd } = this.resolveRunner();
+      const { runnerKey, preset, customCmd } = await this.resolveRunner();
 
-      // Custom command — always full run
       if (runnerKey === 'custom' && customCmd) {
-        await this.execute(customCmd);
+        if (!this.assertTrustedForCustomCommand()) return;
+        await this.execShell(customCmd);
         return;
       }
 
       if (!preset) return;
 
-      // If preset has no scoped command, fall back to full run
-      if (!preset.scopedCommand) {
-        await this.execute(preset.command);
+      if (!preset.scoped) {
+        await this.execArgv(preset.argv);
         return;
       }
 
-      // Compute relative directory of the changed file
       const relDir = path.relative(this.workspaceRoot, path.dirname(filePath));
       if (!relDir || relDir.startsWith('..')) {
-        await this.execute(preset.command);
+        await this.execArgv(preset.argv);
         return;
       }
 
-      const scopedCmd = preset.scopedCommand(relDir);
+      const scoped = preset.scoped(relDir);
       this.log.info(`Scoped run for package: ${relDir}`);
       try {
-        await this.execute(scopedCmd);
+        await this.execArgv(scoped.argv);
       } catch {
         // Tests may fail but still produce coverage data — continue to merge
       }
 
-      // Merge partial coverage into main file if needed
       if (preset.scopedOutput) {
         await this.mergeScoped(preset);
       }
@@ -116,13 +123,13 @@ export class TestRunner {
     }
   }
 
-  private resolveRunner(): { runnerKey: string; preset: RunnerPreset | null; customCmd: string } {
+  private async resolveRunner(): Promise<ResolvedRunner> {
     const cfg = vscode.workspace.getConfiguration('coverlens');
     let runnerKey = cfg.get<string>('testRunner.mode', 'auto');
     const customCmd = cfg.get<string>('testRunner.customCommand', '');
 
     if (runnerKey === 'auto') {
-      runnerKey = detectRunner(this.workspaceRoot);
+      runnerKey = await detectRunner(this.workspaceRoot);
       this.log.info(`Auto-detected runner: ${runnerKey}`);
     }
 
@@ -139,38 +146,77 @@ export class TestRunner {
     return { runnerKey, preset, customCmd: '' };
   }
 
-  private resolveCommand(): string | null {
-    const { runnerKey, preset, customCmd } = this.resolveRunner();
-    if (runnerKey === 'custom' && customCmd) return customCmd;
-    return preset?.command ?? null;
+  /** Workspace Trust gate: refuse to execute user-provided shell strings in untrusted workspaces. */
+  private assertTrustedForCustomCommand(): boolean {
+    if (vscode.workspace.isTrusted) return true;
+    this.log.warn('CoverLens: refusing to run testRunner.customCommand in an untrusted workspace.');
+    vscode.window.showWarningMessage(
+      'CoverLens: custom test commands are disabled in untrusted workspaces. Trust this workspace to enable.'
+    );
+    return false;
   }
 
-  private async execute(command: string): Promise<void> {
-    this.log.info(`Running: ${command}`);
-    await this.exec(command);
+  /** Run a vetted argv array — safe from shell injection because args are passed individually. */
+  private execArgv(argv: string[]): Promise<void> {
+    const [file, ...args] = argv;
+    this.log.info(`Running: ${argv.join(' ')}`);
+    return this.spawnAndWait(file, args, { shell: false });
   }
 
-  private exec(command: string): Promise<void> {
+  /** Run a user-provided shell string (gated by Workspace Trust). */
+  private execShell(command: string): Promise<void> {
+    this.log.info(`Running (shell): ${command}`);
+    return this.spawnAndWait(command, [], { shell: true });
+  }
+
+  private spawnAndWait(file: string, args: string[], opts: { shell: boolean }): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      const timeout = 10 * 60 * 1000; // 10 minutes
-      const proc = cp.exec(command, { cwd: this.workspaceRoot, maxBuffer: 50 * 1024 * 1024, timeout }, (err, stdout, stderr) => {
-        if (this.activeProc === proc) this.activeProc = null;
+      const timeoutMs = 10 * 60 * 1000;
+      const proc = cp.spawn(file, args, {
+        cwd: this.workspaceRoot,
+        shell: opts.shell,
+        windowsHide: true
+      });
+      this.activeProc = proc;
 
-        if (err) {
-          if ((err as any).killed || err.message === 'Cancelled') {
-            this.log.info('Test run aborted.');
-            resolve();
-            return;
-          }
-          this.log.error(stderr || err.message);
-          reject(err);
-        } else {
-          this.log.info('Tests completed.');
-          resolve();
+      let stderrBuf = '';
+      const STDERR_LIMIT = 256 * 1024;
+      proc.stderr?.on('data', (chunk: Buffer) => {
+        if (stderrBuf.length < STDERR_LIMIT) {
+          stderrBuf += chunk.toString();
+          if (stderrBuf.length > STDERR_LIMIT) stderrBuf = stderrBuf.slice(0, STDERR_LIMIT);
         }
       });
+      proc.stdout?.resume();
 
-      this.activeProc = proc;
+      const killTimer = setTimeout(() => {
+        try { proc.kill('SIGTERM'); } catch { /* ignore */ }
+      }, timeoutMs);
+
+      proc.once('error', (err) => {
+        clearTimeout(killTimer);
+        if (this.activeProc === proc) this.activeProc = null;
+        this.log.error(err.message);
+        reject(err);
+      });
+
+      proc.once('close', (code, signal) => {
+        clearTimeout(killTimer);
+        if (this.activeProc === proc) this.activeProc = null;
+
+        if (signal) {
+          this.log.info(`Test run terminated by signal ${signal}.`);
+          resolve();
+          return;
+        }
+        if (code === 0) {
+          this.log.info('Tests completed.');
+          resolve();
+        } else {
+          if (stderrBuf) this.log.error(stderrBuf.trim());
+          reject(new Error(`Test process exited with code ${code}`));
+        }
+      });
     });
   }
 


### PR DESCRIPTION
### Security

- **Workspace Trust** — `coverlens.testRunner.customCommand` is no longer executed in untrusted workspaces. Opening a repository with a malicious `.vscode/settings.json` will not run arbitrary shell code anymore. Declared via the standard `capabilities.untrustedWorkspaces` manifest field.
- **No more shell injection through scoped runs** — built-in presets (Jest/Vitest/pytest/Go) now spawn the runner with an argv array instead of formatting paths into a shell string. A directory whose name contains shell metacharacters can no longer cause command injection during `runOnSave: "package"`.

### Bug Fixes

- **Fixed `.sln` auto-detection never matching** — `detectRunner` was calling `fs.existsSync` with a literal `*.sln` glob. Replaced with a proper directory scan, so .NET projects without a `.csproj` next to the workspace root now resolve to the `dotnet` runner.
- **`runOnSave` no longer triggers for unrelated files** — saves are now filtered by URI scheme (`file:` only), workspace membership and `coverlens.excludePatterns`. Saving a `README.md`, a file in `node_modules`, or a document in another workspace folder no longer kicks off a test run.
- **Initial test run no longer swallows errors silently** — the fire-and-forget `runFullTests()` on activation now logs failures via the CoverLens output channel.

### Improvements

- **Async runner detection with per-workspace cache** — `detectRunner` switched from `fs.*Sync` to `fs.promises.*` and caches its result, removing a synchronous I/O burst from extension activation and from every test run.
- **`enumDescriptions` for enum settings** — VSCode's settings UI now shows per-value documentation for `coverlens.testRunner.mode`, `coverlens.runOnSave`, `coverlens.onEdit` and `coverlens.decorationStyle`.
- **`scope: "resource"` on runner settings** — `coverlens.testRunner.mode`, `coverlens.testRunner.customCommand` and `coverlens.runOnSave` can now be overridden per workspace folder, which matters in monorepos where different packages use different runners.
- **Better test process supervision** — switched from `child_process.exec` to `child_process.spawn`, removing the 50 MB stdout buffer cap and streaming stderr into the log only on non-zero exits.
