### PR TITLE
1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.3
+
+### Bug Fixes
+
+- **No more double-parsing of coverage files in monorepos** ([#7](https://github.com/fogio-org/vscode-coverlens/issues/7)) — when multiple package roots overlapped (e.g. workspace root + a detected sub-package), the same `lcov.info` was discovered and parsed once per root, inflating the `found N coverage file(s)` log and the list passed to `ensureCoverageInGitignore`. `loadCoverage` now accepts a shared `skipPaths` set, and `reload()` threads one across all package iterations so each absolute path is parsed at most once. Also added an explicit `Set` dedup right after `fast-glob` returns, making the "overlapping globs do not duplicate" invariant visible at the call site rather than relying on `fast-glob`'s implicit `unique: true` default.
+
 ## 1.0.2
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "coverlens",
   "displayName": "CoverLens",
   "description": "Three-state coverage lens with diff mode and monorepo support",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "publisher": "fogio",
   "icon": "assets/icon.png",
   "engines": {

--- a/src/__tests__/loader.test.ts
+++ b/src/__tests__/loader.test.ts
@@ -1,0 +1,52 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { loadCoverage } from '../coverage/loader';
+import { Logger } from '../util/logger';
+
+const SAMPLE_LCOV = `
+SF:src/index.ts
+DA:1,1
+DA:2,0
+end_of_record
+`.trim();
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'coverlens-loader-'));
+  const covDir = path.join(tmpRoot, 'coverage');
+  fs.mkdirSync(covDir, { recursive: true });
+  fs.writeFileSync(path.join(covDir, 'lcov.info'), SAMPLE_LCOV);
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+test('overlapping glob patterns do not produce duplicate file entries', async () => {
+  const log = new Logger();
+  const result = await loadCoverage(
+    ['**/lcov.info', '**/coverage/lcov.info', '**/lcov-report/lcov.info'],
+    [],
+    tmpRoot,
+    log
+  );
+
+  expect(result.coverageFiles).toHaveLength(1);
+  expect(result.map.size).toBe(1);
+});
+
+test('skipPaths prevents the same file from being parsed twice across roots', async () => {
+  const log = new Logger();
+  const seen = new Set<string>();
+
+  const first = await loadCoverage(['**/lcov.info'], [], tmpRoot, log, seen);
+  expect(first.coverageFiles).toHaveLength(1);
+  for (const f of first.coverageFiles) seen.add(f);
+
+  // Second call on the same root should find the same file but skip it.
+  const second = await loadCoverage(['**/lcov.info'], [], tmpRoot, log, seen);
+  expect(second.coverageFiles).toHaveLength(0);
+  expect(second.map.size).toBe(0);
+});

--- a/src/coverage/loader.ts
+++ b/src/coverage/loader.ts
@@ -49,13 +49,19 @@ export async function loadCoverage(
   globs: string[],
   excludePatterns: string[],
   workspaceRoot: string,
-  log: Logger
+  log: Logger,
+  skipPaths?: Set<string>
 ): Promise<LoadResult> {
-  const files = await fg.glob(globs, {
+  const matched = await fg.glob(globs, {
     cwd: workspaceRoot,
     absolute: true,
     ignore: excludePatterns
   });
+
+  // Overlapping glob patterns (e.g. **/lcov.info and **/coverage/lcov.info)
+  // can match the same file; skipPaths lets the caller dedupe across multiple
+  // workspaceRoots in monorepo mode.
+  const files = [...new Set(matched)].filter(f => !skipPaths?.has(f));
 
   log.info(`CoverLens: found ${files.length} coverage file(s)`);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,10 +69,12 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
 
       const merged: CoverageMap = new Map();
       const allCoverageFiles: string[] = [];
+      const seen = new Set<string>();
       for (const pkg of packages) {
         try {
-          const result = await loadCoverage(globs, exclude, pkg, log);
+          const result = await loadCoverage(globs, exclude, pkg, log, seen);
           for (const [k, v] of result.map) merged.set(k, v);
+          for (const f of result.coverageFiles) seen.add(f);
           allCoverageFiles.push(...result.coverageFiles);
         } catch (err) {
           log.warn(`Failed to load coverage for ${pkg}: ${err}`);


### PR DESCRIPTION
### Bug Fixes

- **No more double-parsing of coverage files in monorepos** ([#7](https://github.com/fogio-org/vscode-coverlens/issues/7)) — when multiple package roots overlapped (e.g. workspace root + a detected sub-package), the same `lcov.info` was discovered and parsed once per root, inflating the `found N coverage file(s)` log and the list passed to `ensureCoverageInGitignore`. `loadCoverage` now accepts a shared `skipPaths` set, and `reload()` threads one across all package iterations so each absolute path is parsed at most once. Also added an explicit `Set` dedup right after `fast-glob` returns, making the "overlapping globs do not duplicate" invariant visible at the call site rather than relying on `fast-glob`'s implicit `unique: true` default.