### PR TITLE
1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.4
+
+### Improvements
+
+- **Wider editor compatibility** ([#10](https://github.com/fogio-org/vscode-coverlens/issues/10)) — lowered the required `engines.vscode` from `^1.110.0` to `^1.96.0` and pinned `@types/vscode` to `1.96.0`. The extension only uses VS Code APIs available since 1.56 (`workspace.isTrusted` is the newest), so the higher floor was excluding editors that ship an older extension host. CoverLens now installs without an engine-compatibility warning in Cursor, Windsurf, VSCodium and other 1.96+ hosts. The pinned `@types/vscode` makes the compiler enforce the floor, so a newer API can no longer slip in unnoticed.
+
 ## 1.0.3
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coverlens",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coverlens",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -16,7 +16,7 @@
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/node": "^25.5.0",
-        "@types/vscode": "1.105.0",
+        "@types/vscode": "1.96.0",
         "@types/xml2js": "^0.4.14",
         "@typescript-eslint/eslint-plugin": "^8.58.0",
         "@typescript-eslint/parser": "^8.58.0",
@@ -31,7 +31,7 @@
         "webpack-cli": "^7.0.2"
       },
       "engines": {
-        "vscode": "^1.105.0"
+        "vscode": "^1.96.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -2033,9 +2033,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.105.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.105.0.tgz",
-      "integrity": "sha512-Lotk3CTFlGZN8ray4VxJE7axIyLZZETQJVWi/lYoUVQuqfRxlQhVOfoejsD2V3dVXPSbS15ov5ZyowMAzgUqcw==",
+      "version": "1.96.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.96.0.tgz",
+      "integrity": "sha512-qvZbSZo+K4ZYmmDuaodMbAa67Pl6VDQzLKFka6rq+3WUTY4Kro7Bwoi0CuZLO/wema0ygcmpwow7zZfPJTs5jg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coverlens",
-  "version": "0.5.0",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coverlens",
-      "version": "0.5.0",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -16,7 +16,7 @@
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/node": "^25.5.0",
-        "@types/vscode": "^1.110.0",
+        "@types/vscode": "1.105.0",
         "@types/xml2js": "^0.4.14",
         "@typescript-eslint/eslint-plugin": "^8.58.0",
         "@typescript-eslint/parser": "^8.58.0",
@@ -31,7 +31,7 @@
         "webpack-cli": "^7.0.2"
       },
       "engines": {
-        "vscode": "^1.110.0"
+        "vscode": "^1.105.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -2033,9 +2033,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.110.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.110.0.tgz",
-      "integrity": "sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==",
+      "version": "1.105.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.105.0.tgz",
+      "integrity": "sha512-Lotk3CTFlGZN8ray4VxJE7axIyLZZETQJVWi/lYoUVQuqfRxlQhVOfoejsD2V3dVXPSbS15ov5ZyowMAzgUqcw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2427,9 +2427,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2444,9 +2441,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2461,9 +2455,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2478,9 +2469,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2495,9 +2483,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2512,9 +2497,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2529,9 +2511,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2546,9 +2525,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "publisher": "fogio",
   "icon": "assets/icon.png",
   "engines": {
-    "vscode": "^1.110.0"
+    "vscode": "^1.105.0"
   },
   "license": "MIT",
   "repository": {
@@ -191,7 +191,11 @@
         },
         "coverlens.onEdit": {
           "type": "string",
-          "enum": ["hide", "dim", "keep"],
+          "enum": [
+            "hide",
+            "dim",
+            "keep"
+          ],
           "enumDescriptions": [
             "Remove decorations once the file is dirty",
             "Show decorations faded while the file is dirty",
@@ -202,7 +206,11 @@
         },
         "coverlens.runOnSave": {
           "type": "string",
-          "enum": ["off", "package", "all"],
+          "enum": [
+            "off",
+            "package",
+            "all"
+          ],
           "enumDescriptions": [
             "Do not run tests on save",
             "Run only the package/directory containing the saved file",
@@ -301,7 +309,7 @@
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^25.5.0",
-    "@types/vscode": "^1.110.0",
+    "@types/vscode": "1.105.0",
     "@types/xml2js": "^0.4.14",
     "@typescript-eslint/eslint-plugin": "^8.58.0",
     "@typescript-eslint/parser": "^8.58.0",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "coverlens",
   "displayName": "CoverLens",
   "description": "Three-state coverage lens with diff mode and monorepo support",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "publisher": "fogio",
   "icon": "assets/icon.png",
   "engines": {
-    "vscode": "^1.105.0"
+    "vscode": "^1.96.0"
   },
   "license": "MIT",
   "repository": {
@@ -309,7 +309,7 @@
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^25.5.0",
-    "@types/vscode": "1.105.0",
+    "@types/vscode": "1.96.0",
     "@types/xml2js": "^0.4.14",
     "@typescript-eslint/eslint-plugin": "^8.58.0",
     "@typescript-eslint/parser": "^8.58.0",


### PR DESCRIPTION
### Improvements

- **Wider editor compatibility** ([#10](https://github.com/fogio-org/vscode-coverlens/issues/10)) — lowered the required `engines.vscode` from `^1.110.0` to `^1.96.0` and pinned `@types/vscode` to `1.96.0`. The extension only uses VS Code APIs available since 1.56 (`workspace.isTrusted` is the newest), so the higher floor was excluding editors that ship an older extension host. CoverLens now installs without an engine-compatibility warning in Cursor, Windsurf, VSCodium and other 1.96+ hosts. The pinned `@types/vscode` makes the compiler enforce the floor, so a newer API can no longer slip in unnoticed.